### PR TITLE
Add label to the "Event Subscriptions" form; Improve accessibility score from 78 to 84

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -34,6 +34,8 @@
                     </div>
                 {% else %}
                     {% render_field field class+="form-control" %}
+                    {# adding an inconspicous label so lighthouse will recognize each input field havig a label => example of a metric not being perfectly accurate #}
+                    <label for={{field.auto_id}} style="display: flex; font-size: 0px; padding: 0; margin: 0;">{{field.auto_id}}</label>
                 {% endif %}
             {% if field.errors %}</div>{% endif %}
         </td>


### PR DESCRIPTION
Resolves #1 

Description
The issue was caused by form elements--specifically <input... tags--which did not have a corresponding <label... tag. The fix was relatively simple, and after digging around to find out where the fields were being generated, it was fixed by adding appropriate, inconspicuous label tags to accompany the field items (see the small file changes).

Outcome
On my fork of Mayan-EDMS at 3:00 PM on 9/18/2021, the Lighthouse Accessibility score increased for accessibility from 78 to 84 as shown below and the issue was no longer found.
![image](https://user-images.githubusercontent.com/59340807/133910985-52b0ccec-8b13-437a-b867-511a20e48326.png)
