### PR TITLE
adding label before form elements

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -33,6 +33,7 @@
                         {% endfor %}
                     </div>
                 {% else %}
+                    {{ field.label_tag }}
                     {% render_field field class+="form-control" %}
                 {% endif %}
             {% if field.errors %}</div>{% endif %}


### PR DESCRIPTION
Resolves #5

After locating the Django template for generic form instances, a generic label is created for each form element to increase accessibility.
We observe an improvement of lighthouse score from 85 to 89.
This implementation is more modularized and defers the work of creating labels when the table elements are generated.